### PR TITLE
[Bug FIX] CVCの型をnumberからstringへ

### DIFF
--- a/lib/spike-api.js
+++ b/lib/spike-api.js
@@ -148,7 +148,7 @@ SpikeAPI.prototype.postToken = function(cardData, callback) {
     'card[number]': 4444333322221111, // Number of credit card
     'card[exp_month]': 1, // Expire month of credit card
     'card[exp_year]': 2020, // Expire year of credit card
-    'card[cvc]': 111, // Cvc of credit card
+    'card[cvc]': '012', // Cvc of credit card
     'card[name]': '', // Name of credit card holder
     'currency': 'JPY', // Currency code
     'email': '' // Email of credit card holder
@@ -159,7 +159,7 @@ SpikeAPI.prototype.postToken = function(cardData, callback) {
     'Number', 
     'Number', 
     'Number', 
-    'Number', 
+    'String', // CVC requires beginning zero e.g. "060", "111", 
     'String', 
     'String', 
     'String', 

--- a/test/spike-api.js
+++ b/test/spike-api.js
@@ -28,7 +28,7 @@ var testConfig = isActualTest ?
       cardNumber: 4444333322221111,
       cardExpMonth: 1,
       cardExpYear: (new Date()).getFullYear() + 1,
-      cardCvc: 111,
+      cardCvc: '012',
       cardName: 'KATSUAKI SATO'
     };
 


### PR DESCRIPTION
@ynakajima さま

以前私が実装した箇所の不具合修正になります。
CVCをnumber型にしていたのですが、0で始まる場合CVCの場合に桁数が足りなくなるなどの不具合があったためstringへと変更致しました。

ご確認頂けますと幸いです。
